### PR TITLE
Only print stdout lines and not entire registered variable

### DIFF
--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -41,12 +41,12 @@
 
 - name: Print cluster info
   debug:
-    var: cluster_info
+    var: cluster_info.stdout_lines
   tags: redis_cluster
 
 - name: Create a redis cluster
   command: "{{ redis_cluster_command }}"
-  when: 'cluster_info.rc == 0 and "cluster_known_nodes:1" in cluster_info.stdout'
+  when: 'cluster_info.rc == 0 and "cluster_known_nodes:1" in cluster_info.stdout_lines'
   register: cluster_creation_result
   tags: redis_cluster
 


### PR DESCRIPTION
Only print stdout lines of registered variable `cluster_info` and not the entire registered variable.

Closes #6.