### PR TITLE
Fixes for Ansible 2.15 and newer

### DIFF
--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -21,9 +21,9 @@
       --cluster-yes
       {% if redis_configurations[0]['redis_tls_cluster'] is defined
           and redis_configurations[0]['redis_tls_cluster'] == 'yes' %}
-        --tls --cert {{ redis_configurations [0]['redis_tls_cert_file'] }}
-        --key {{ redis_configurations [0]['redis_tls_key_file'] }}
-        --cacert {{ redis_configurations [0]['redis_tls_ca_cert_file'] }}
+        --tls --cert {{ redis_configurations[0]['redis_tls_cert_file'] }}
+        --key {{ redis_configurations[0]['redis_tls_key_file'] }}
+        --cacert {{ redis_configurations[0]['redis_tls_ca_cert_file'] }}
       {% endif %}
   tags: redis_cluster
 
@@ -33,7 +33,7 @@
   tags: redis_cluster
 
 - name: Get redis cluster info
-  command: "redis-cli -h {{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }} -p {% if redis_configurations [0]['redis_tls_cluster'] is defined and redis_configurations[0]['redis_tls_cluster'] == 'yes' %} {{ redis_configurations [0]['redis_tls_port'] }} {% else %} {{ redis_configurations [0]['redis_port'] }} {% endif %} {% if redis_configurations[0]['redis_tls_cluster'] is defined and redis_configurations[0]['redis_tls_cluster'] == 'yes' %} --tls --cert {{ redis_configurations [0]['redis_tls_cert_file'] }} --key {{ redis_configurations [0]['redis_tls_key_file'] }} --cacert {{ redis_configurations [0]['redis_tls_ca_cert_file'] }} {% endif %} -a {{ redis_requirepass }} CLUSTER INFO"
+  command: "redis-cli -h {{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }} -p {% if redis_configurations[0]['redis_tls_cluster'] is defined and redis_configurations[0]['redis_tls_cluster'] == 'yes' %} {{ redis_configurations[0]['redis_tls_port'] }} {% else %} {{ redis_configurations[0]['redis_port'] }} {% endif %} {% if redis_configurations[0]['redis_tls_cluster'] is defined and redis_configurations[0]['redis_tls_cluster'] == 'yes' %} --tls --cert {{ redis_configurations[0]['redis_tls_cert_file'] }} --key {{ redis_configurations[0]['redis_tls_key_file'] }} --cacert {{ redis_configurations[0]['redis_tls_ca_cert_file'] }} {% endif %} -a {{ redis_requirepass }} CLUSTER INFO"
   register: cluster_info
   changed_when: false
   failed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,14 +24,16 @@
     redis_ports: >-
       {%- set redis_ports = [] -%}
       {%- for i in redis_configurations -%}
-        {%- if i['redis_tls_port'] is defined -%}
-          {%- set redis_port = i['redis_tls_port'] -%}
-        {%- else -%}
-          {%- set redis_port = i['redis_port'] -%}
+        {%- if i['redis_port'] is defined -%}
+          {%- set port = i['redis_port'] -%}
+          {{ redis_ports.append(port) }}
         {%- endif -%}
-        {{ redis_ports.append(redis_port) }}
-        {%- if redis_installation_scenario == 'cluster' -%}
-          {{ redis_ports.append(redis_port |int + 10000) }}
+        {%- if i['redis_tls_port'] is defined -%}
+          {%- set port = i['redis_tls_port'] -%}
+          {{ redis_ports.append(port) }}
+          {%- if redis_installation_scenario == 'cluster' -%}
+            {{ redis_ports.append(port|int + 10000) }}
+          {%- endif -%}
         {%- endif -%}
       {%- endfor -%}
       {{ redis_ports | join(',') }}


### PR DESCRIPTION
The whitespace characters in `tasks/cluster.yml` are causing the cluster creation to fail on control nodes with Ansible Core 2.15 and newer.

Assembling the Redis ports fact in `tasks/main.yml` does not take the plain port into consideration if `redis_tls_port` is defined.

Resolves #22.